### PR TITLE
Fix cookies formatting (#82)

### DIFF
--- a/http/server.lua
+++ b/http/server.lua
@@ -279,14 +279,14 @@ local function setcookie(resp, cookie)
 
     local str = sprintf('%s=%s', name, uri_escape(value))
     if cookie.path ~= nil then
-        str = sprintf('%s;path=%s', str, uri_escape(cookie.path))
+        str = sprintf('%s;path=%s', str, cookie.path)
     end
     if cookie.domain ~= nil then
         str = sprintf('%s;domain=%s', str, cookie.domain)
     end
 
     if cookie.expires ~= nil then
-        str = sprintf('%s;expires="%s"', str, expires_str(cookie.expires))
+        str = sprintf('%s;expires=%s', str, expires_str(cookie.expires))
     end
 
     if not resp.headers then


### PR DESCRIPTION
Stop url-encoding cookie path quoting cookie expire date

From RFC 6265 (4.1.1 section):
 expires-av        = "Expires=" sane-cookie-date
 sane-cookie-date  = <rfc1123-date, defined in [RFC2616], Section 3.3.1>